### PR TITLE
fix: specify `python_min` version with `>=`

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -42,7 +42,7 @@ requirements:
 
 tests:
   - python:
-      python_version: ${{ python_min }}
+      python_version: ">=${{ python_min }}"
       imports:
         - haystack
       pip_check: true


### PR DESCRIPTION
Automation in https://github.com/conda-forge/haystack-ai-feedstock is broken. Currently blocks us from making releases on conda.

error in the build log is here:
https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1262766&view=logs&j=7b6f2c87-f3a7-5133-8d84-7c03a75d9dfc&t=9eb77fd2-8ddd-5444-8fc0-71cb28dcb736

```
[[ -f /home/conda/feedstock_root/LICENSE.txt ]]
+ cp /home/conda/feedstock_root/LICENSE.txt /home/conda/recipe_root/recipe-scripts-license.txt
+ [[ 0 == 1 ]]
+ rattler-build build --recipe /home/conda/recipe_root -m /home/conda/feedstock_root/.ci_support/linux_64_.yaml --target-platform linux-64 --extra-meta flow_run_id=azure_20250606.1.1 --extra-meta remote_url=https://github.com/conda-forge/haystack-ai-feedstock --extra-meta sha=7679521a0ff0356cc0b4aeea3411ab8b52405355

 ╭─ Finding outputs from recipe
 │ Loading variant config file: "/home/conda/feedstock_root/.ci_support/linux_64_.yaml"
 │
 ╰─────────────────── (took 0 seconds)
Error:   × Failed to parse recipe

Error: 
  × failed to parse match spec: missing range specifier for '3.9'. Did you
  │ mean '==3.9' or '3.9.*'?
    ╭─[recipe_root/recipe.yaml:45:23]
 44 │   - python:
 45 │       python_version: ${{ python_min }}
    ·                       ────────┬────────
    ·                               ╰── error parsing `3.9` as a version specification
 46 │       imports:
    ╰────
```